### PR TITLE
Implement commit message parser

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,8 @@ rust-version = "1.69"
 [workspace.dependencies]
 
 # Local dependencies
-sleppa_configuration = { path = "crates/sleppa_configuration", version = "0.1.0" }
-sleppa_commit_analyzer = { path = "crates/sleppa_commit_analyzer", version = "0.1.0" }
+sleppa_configuration = { version = "0.1.0", path = "crates/sleppa_configuration" }
+sleppa_commit_analyzer = { version = "0.1.0", path = "crates/sleppa_commit_analyzer" }
 
 # Errors processing
 thiserror = { version = "1.0.40" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,15 @@ repository = "https://github.com/SofairOfficial/sleppa"
 edition = "2021"
 rust-version = "1.69"
 
+
 # Global dependencies
 [workspace.dependencies]
+
+# Local dependencies
+sleppa_configuration = { path = "crates/sleppa_configuration", version = "0.1.0" }
+sleppa_commit_analyzer = { path = "crates/sleppa_commit_analyzer", version = "0.1.0" }
+
+# Errors processing
 thiserror = { version = "1.0.40" }
 
 [profile.release]

--- a/crates/sleppa_commit_analyzer/Cargo.toml
+++ b/crates/sleppa_commit_analyzer/Cargo.toml
@@ -1,0 +1,40 @@
+[package]
+name = "sleppa_commit_analyzer"
+description = "Retrieve commits inside squashed commit and analyze their message to provide a release type."
+version = "0.1.0"
+
+keywords = ["Sleppa", "release-automation", "semantic-release", "git-commit"]
+
+categories = ["development tools"]
+
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+documentation.workspace = true
+homepage.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+
+# Local dependencies
+sleppa_configuration = { workspace = true }
+
+# External dependencies
+serde = { version = "^1.0.160", features = ["derive"] }
+regex = { version = "^1.8.1" }
+octocrab = { version = "^0.20.0" }
+tokio = { version = "1.28.0", features = ["macros"] }
+url = { version = "2.2.2", features = ["serde"] }
+
+# Errors and logs processing
+thiserror = { workspace = true }
+
+[dev-dependencies]
+tokio = { version = "1.28.0", default-features = false, features = ["macros"] }
+tokio-test = "0.4.2"
+
+[lib]
+name = "sleppa_commit_analyzer"
+crate-type = ["lib"]
+path = "src/lib.rs"

--- a/crates/sleppa_commit_analyzer/Cargo.toml
+++ b/crates/sleppa_commit_analyzer/Cargo.toml
@@ -21,18 +21,18 @@ rust-version.workspace = true
 sleppa_configuration = { workspace = true }
 
 # External dependencies
-serde = { version = "^1.0.160", features = ["derive"] }
-regex = { version = "^1.8.1" }
+async-trait = { version = "0.1.68" }
 octocrab = { version = "^0.20.0" }
+regex = { version = "^1.8.1" }
+serde = { version = "^1.0.160", features = ["derive"] }
 tokio = { version = "1.28.0", features = ["macros"] }
-url = { version = "2.2.2", features = ["serde"] }
 
 # Errors and logs processing
 thiserror = { workspace = true }
 
 [dev-dependencies]
 tokio = { version = "1.28.0", default-features = false, features = ["macros"] }
-tokio-test = "0.4.2"
+tokio-test = { version = "0.4.2" }
 
 [lib]
 name = "sleppa_commit_analyzer"

--- a/crates/sleppa_commit_analyzer/Cargo.toml
+++ b/crates/sleppa_commit_analyzer/Cargo.toml
@@ -25,7 +25,6 @@ async-trait = { version = "0.1.68" }
 octocrab = { version = "^0.20.0" }
 regex = { version = "^1.8.1" }
 serde = { version = "^1.0.160", features = ["derive"] }
-tokio = { version = "1.28.0", features = ["macros"] }
 
 # Errors and logs processing
 thiserror = { workspace = true }

--- a/crates/sleppa_commit_analyzer/Cargo.toml
+++ b/crates/sleppa_commit_analyzer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sleppa_commit_analyzer"
-description = "Retrieve commits inside squashed commit and analyze their message to provide a release type."
+description = "Analyzer calculating a semantic release version based on commit messages contents."
 version = "0.1.0"
 
 keywords = ["Sleppa", "release-automation", "semantic-release", "git-commit"]

--- a/crates/sleppa_commit_analyzer/README.md
+++ b/crates/sleppa_commit_analyzer/README.md
@@ -1,0 +1,36 @@
+# Sleppa commit message parser
+
+Original [semantic-release](https://github.com/semantic-release/semantic-release/discussions) is a very powerful tool to operate semantic release. It automates the whole package release workflow including: determining the next version number, generating the release notes, and publishing the package.
+
+As we are using squash-and-merge strategy to keep a clean and lean history, we have to be able to read the message of squashed commits.
+Our strategy is as follows :
+
+- Creating a new branch to operate change. The branch name will be the message of the squashed commits.
+- Do some commits on this branch (named inner commit) with valid conventionnal commit message.
+- Create a pull request (PR) with a valid name like: `Issue to solve (#3)` where the number `3` is the number of the PR.
+- Squash-and-merge the PR with the valid name.
+
+## How it works
+
+If the squash-and-merged strategy is applied from the beginning, the first initial commit is the only one which is not.
+Therefore, each following commit will be a PR (with a valid name) containing inner commits.
+From the last known tag, these PR will be peeled to analyze their inner commit's messages. As these messages look like the
+provided `grammar`, they can be parsed to match the type of the `ReleaseAction`.
+
+The table below shows which commit message gets you which release type from the `grammar` and a `Regex format` :
+
+| Commit message example                                                            | Release type |
+| --------------------------------------------------------------------------------- | ------------ |
+| `break(cpu): upgrade from 32 to 64 bits`                                          | Major        |
+| `feat(cpu): add L1 cache`                                                         | Minor        |
+| `fix(cpu): add RAM memory to allow swapping`                                      | Patch        |
+
+| Grammar using Regex format (defined in the `sleppa.tom`)                          | Release type |
+| --------------------------------------------------------------------------------- | ------------ |
+| `^(?P<type>break){1}(?P<scope>\(\S.*\S\))?:\s.*[a-z0-9]$`                         | Major        |
+| `^(?P<type>build|ci|docs|feat){1}(?P<scope>\(\S.*\S\))?:\s.*[a-z0-9]$`            | Minor        |
+| `^(?P<type>fix|perf|refac|sec|style|test){1}(?P<scope>\(\S.*\S\))?:\s.*[a-z0-9]$` | Patch        |
+
+### View of a squashed PR with inner commits
+
+![Alt text](https://user-images.githubusercontent.com/15166875/229083489-82a73e59-7f64-468a-88f7-8714d0630e37.png "squashed commit")

--- a/crates/sleppa_commit_analyzer/README.md
+++ b/crates/sleppa_commit_analyzer/README.md
@@ -1,6 +1,8 @@
 # Sleppa commit message parser
 
-Original [semantic-release](https://github.com/semantic-release/semantic-release/discussions) is a very powerful tool to operate semantic release. It automates the whole package release workflow including: determining the next version number, generating the release notes, and publishing the package.
+Original [semantic-release](https://github.com/semantic-release/semantic-release/discussions) is a very powerful tool to operate semantic release. It automates the whole package release workflow including the computation of next [semantic release](https://semver.org) number, the generation of release notes and the publication of the final package.
+
+This crate `sleppa_commit_analyzer` is opiniated because it uses a squash-and-merge commit strategy. However Sleppa wants to be agnostic of commit strategies. Another commit analyzer, using a rebase strategy for instance, can be used in Sleppa thanks to the trait `Repository`.
 
 As we are using squash-and-merge strategy to keep a clean and lean history, we have to be able to read the message of squashed commits.
 Our strategy is as follows :
@@ -14,7 +16,19 @@ Our strategy is as follows :
 
 If the squash-and-merged strategy is applied from the beginning, the first initial commit is the only one which is not.
 Therefore, each following commit will be a PR (with a valid name) containing inner commits.
-From the last known tag, these PR will be peeled to analyze their inner commit's messages. As these messages look like the
+
+```
+Branch to merge
+^
+|-squash commit name (#13)
+                        ^
+                        |----pull request number
+                             ^
+                             |-- inner commit 1: "feat(github): some inner commit message"
+                             |-- inner commit 2: "docs: some inner commit message"
+```
+
+From the last known tag, these PR will be peeled to analyze their inner commit messages. As these messages look like the
 provided `grammar`, they can be parsed to match the type of the `ReleaseAction`.
 
 The table below shows which commit message gets you which release type from the `grammar` and a `Regex format` :
@@ -25,12 +39,8 @@ The table below shows which commit message gets you which release type from the 
 | `feat(cpu): add L1 cache`                                                         | Minor        |
 | `fix(cpu): add RAM memory to allow swapping`                                      | Patch        |
 
-| Grammar using Regex format (defined in the `sleppa.tom`)                          | Release type |
+| Grammar using Regex format (defined in the `sleppa.toml`)                         | Release type |
 | --------------------------------------------------------------------------------- | ------------ |
 | `^(?P<type>break){1}(?P<scope>\(\S.*\S\))?:\s.*[a-z0-9]$`                         | Major        |
-| `^(?P<type>build|ci|docs|feat){1}(?P<scope>\(\S.*\S\))?:\s.*[a-z0-9]$`            | Minor        |
-| `^(?P<type>fix|perf|refac|sec|style|test){1}(?P<scope>\(\S.*\S\))?:\s.*[a-z0-9]$` | Patch        |
-
-### View of a squashed PR with inner commits
-
-![Alt text](https://user-images.githubusercontent.com/15166875/229083489-82a73e59-7f64-468a-88f7-8714d0630e37.png "squashed commit")
+| `^(?P<type>build\|ci\|docs\|feat){1}(?P<scope>\(\S.*\S\))?:\s.*[a-z0-9]$`         | Minor        |
+| `^(?P<type>fix\|perf\|refac\|sec\|style\|test){1}(?P<scope>\(\S.*\S\))?:\s.*[a-z0-9]$` | Patch        |

--- a/crates/sleppa_commit_analyzer/src/errors.rs
+++ b/crates/sleppa_commit_analyzer/src/errors.rs
@@ -7,15 +7,15 @@ use serde::Deserialize;
 /// while getting and parsing commit's message.
 #[derive(thiserror::Error, Debug, Deserialize)]
 pub enum CommitAnalyzerError {
-    // No release action type match found
+    /// No release action type match found
     #[error("No release action found")]
     ErrorNoMatching(),
 
-    // Message is not correct
+    /// Message is not correct
     #[error("No release action found")]
     InvalidMessage(),
 
-    // Chained errors occuring when processing with GitHub
+    /// Chained errors occuring in GitHub API
     #[error(transparent)]
     GithubError(#[from] GitHubError),
 }

--- a/crates/sleppa_commit_analyzer/src/errors.rs
+++ b/crates/sleppa_commit_analyzer/src/errors.rs
@@ -1,0 +1,24 @@
+use octocrab::GitHubError;
+use serde::Deserialize;
+
+/// Error enumeration for the commit message analyzer parser module.
+///
+/// This list is a central structure aiming to define errors that can occur
+/// while getting and parsing commit's message.
+#[derive(thiserror::Error, Debug, Deserialize)]
+pub enum CommitAnalyzerError {
+    // No release action type match found
+    #[error("No release action found")]
+    ErrorNoMatching(),
+
+    // Message is not correct
+    #[error("No release action found")]
+    InvalidMessage(),
+
+    // Chained errors occuring when processing with GitHub
+    #[error(transparent)]
+    GithubError(#[from] GitHubError),
+}
+
+/// Definition of the commit analyzer result
+pub type CommitAnalyzerResult<R> = Result<R, CommitAnalyzerError>;

--- a/crates/sleppa_commit_analyzer/src/lib.rs
+++ b/crates/sleppa_commit_analyzer/src/lib.rs
@@ -5,68 +5,45 @@
 //! Thanks to the crate [sleppa_configuration], the [Configuration] contains the [ReleaseRule] to apply
 //! for each [ReleaseAction]. These can be used to parsed the commit's messages.
 //!
-//! In order to match a new [ReleaseAction], the commit's message from the last tag must be retrieved.
-//! They will be stored in a structure [MessagesToAnalyze].
-//!
-//! The trait [CommitHandler] is used to bring the commit's messages to the [CommitAnalyzer] with the
-//! [MessagesToAnalyze] structure.
+//! In order to match a new [ReleaseAction], the commit's messages from the last tag must be retrieved.
 //!
 //! As only one release action type must be defined for a new release, only the higher one is kept :
 //! - Major > Minor > Patch
 
 mod errors;
-//mod github;
+mod repositories;
 
 use errors::*;
 use sleppa_configuration::*;
 
+///
+///
 #[derive(Debug, Default)]
 pub struct CommitAnalyzer {}
 
-/// Handles all the messages that must be analyzed
-///
-/// It is used to store all the commit's message retrieved since the last tag of a repository
-#[derive(Debug, Default)]
-pub struct MessagesToAnalyze {
-    messages: Vec<String>,
-}
-
 impl CommitAnalyzer {
-    /// Parses a message and matches a ReleaseAction
+    /// Verifies multiple commit's message to retrieve the higher release action type to apply.
     ///
-    /// This function reads a provided message and verify if the message matches a ReleaseAction
-    /// thanks to the trait [ReleaseRuleHandler].
-    /// If no match is found, a [CommitAnalyzerError] is returned.
-    pub fn execute(&self, message: &str, release_rule: &ReleaseRules) -> CommitAnalyzerResult<ReleaseAction> {
-        if release_rule[&ReleaseAction::Major].handle(message).is_ok() {
-            Ok(ReleaseAction::Major)
-        } else if release_rule[&ReleaseAction::Minor].handle(message).is_ok() {
-            Ok(ReleaseAction::Minor)
-        } else if release_rule[&ReleaseAction::Patch].handle(message).is_ok() {
-            Ok(ReleaseAction::Patch)
-        } else {
-            Err(CommitAnalyzerError::ErrorNoMatching())
-        }
-    }
-
-    /// Verifies multiple commit's message to retrieve the higher release action type to apply
-    ///
-    /// This function receives [MessageToAnalyze] struct and analyzes them to retrieve the release action
+    /// This function receives an array of strings and analyzes them to retrieve the release action
     /// type to apply since the last tag.
     /// As it is impossible to have two release action types at the same time, only the higher one is kept.
-    pub fn action_to_release(&self, mes: MessagesToAnalyze, release_rule: &ReleaseRules) -> Option<ReleaseAction> {
+    pub fn analyze(&self, commit_messages: Vec<String>, rules: &ReleaseRules) -> Option<ReleaseAction> {
         let mut major_count = 0;
         let mut minor_count = 0;
         let mut patch_count = 0;
-        let mut _no_type = 0;
-        for message in mes.messages {
-            match self.execute(&message, release_rule) {
+
+        // Matches the release action type according to the message in commit_messages.
+        for message in commit_messages {
+            match self.execute(&message, rules) {
                 Ok(ReleaseAction::Major) => major_count += 1,
                 Ok(ReleaseAction::Minor) => minor_count += 1,
                 Ok(ReleaseAction::Patch) => patch_count += 1,
-                _ => _no_type += 1,
+                Err(_err) => continue,
             }
         }
+
+        // Returns only the higher action release type.
+        // Major > Minor > Patch
         if major_count > 0 {
             Some(ReleaseAction::Major)
         } else if minor_count > 0 {
@@ -77,10 +54,23 @@ impl CommitAnalyzer {
             None
         }
     }
-}
 
-pub trait CommitHandler {
-    fn get_messages_from_last_tag(&self) -> MessagesToAnalyze;
+    /// Parses a message and matches a ReleaseAction.
+    ///
+    /// This function reads a provided message and verify if the message matches a ReleaseAction
+    /// thanks to the trait [ReleaseRuleHandler].
+    /// If no match is found, a [CommitAnalyzerError] is returned.
+    fn execute(&self, message: &str, release_rule: &ReleaseRules) -> CommitAnalyzerResult<ReleaseAction> {
+        if release_rule[&ReleaseAction::Major].handle(message).is_ok() {
+            Ok(ReleaseAction::Major)
+        } else if release_rule[&ReleaseAction::Minor].handle(message).is_ok() {
+            Ok(ReleaseAction::Minor)
+        } else if release_rule[&ReleaseAction::Patch].handle(message).is_ok() {
+            Ok(ReleaseAction::Patch)
+        } else {
+            Err(CommitAnalyzerError::ErrorNoMatching())
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/sleppa_commit_analyzer/src/lib.rs
+++ b/crates/sleppa_commit_analyzer/src/lib.rs
@@ -1,0 +1,87 @@
+//! Sleppa commit analyzer package
+//!
+//! This crate reads the commit's messages and matches a release action type.
+//!
+//! Thanks to the crate [sleppa_configuration], the [Configuration] contains the [ReleaseRule] to apply
+//! for each [ReleaseAction]. These can be used to parsed the commit's messages.
+//!
+//! In order to match a new [ReleaseAction], the commit's message from the last tag must be retrieved.
+//! They will be stored in a structure [MessagesToAnalyze].
+//!
+//! The trait [CommitHandler] is used to bring the commit's messages to the [CommitAnalyzer] with the
+//! [MessagesToAnalyze] structure.
+//!
+//! As only one release action type must be defined for a new release, only the higher one is kept :
+//! - Major > Minor > Patch
+
+mod errors;
+//mod github;
+
+use errors::*;
+use sleppa_configuration::*;
+
+#[derive(Debug, Default)]
+pub struct CommitAnalyzer {}
+
+/// Handles all the messages that must be analyzed
+///
+/// It is used to store all the commit's message retrieved since the last tag of a repository
+#[derive(Debug, Default)]
+pub struct MessagesToAnalyze {
+    messages: Vec<String>,
+}
+
+impl CommitAnalyzer {
+    /// Parses a message and matches a ReleaseAction
+    ///
+    /// This function reads a provided message and verify if the message matches a ReleaseAction
+    /// thanks to the trait [ReleaseRuleHandler].
+    /// If no match is found, a [CommitAnalyzerError] is returned.
+    pub fn execute(&self, message: &str, release_rule: &ReleaseRules) -> CommitAnalyzerResult<ReleaseAction> {
+        if release_rule[&ReleaseAction::Major].handle(message).is_ok() {
+            Ok(ReleaseAction::Major)
+        } else if release_rule[&ReleaseAction::Minor].handle(message).is_ok() {
+            Ok(ReleaseAction::Minor)
+        } else if release_rule[&ReleaseAction::Patch].handle(message).is_ok() {
+            Ok(ReleaseAction::Patch)
+        } else {
+            Err(CommitAnalyzerError::ErrorNoMatching())
+        }
+    }
+
+    /// Verifies multiple commit's message to retrieve the higher release action type to apply
+    ///
+    /// This function receives [MessageToAnalyze] struct and analyzes them to retrieve the release action
+    /// type to apply since the last tag.
+    /// As it is impossible to have two release action types at the same time, only the higher one is kept.
+    pub fn action_to_release(&self, mes: MessagesToAnalyze, release_rule: &ReleaseRules) -> Option<ReleaseAction> {
+        let mut major_count = 0;
+        let mut minor_count = 0;
+        let mut patch_count = 0;
+        let mut _no_type = 0;
+        for message in mes.messages {
+            match self.execute(&message, release_rule) {
+                Ok(ReleaseAction::Major) => major_count += 1,
+                Ok(ReleaseAction::Minor) => minor_count += 1,
+                Ok(ReleaseAction::Patch) => patch_count += 1,
+                _ => _no_type += 1,
+            }
+        }
+        if major_count > 0 {
+            Some(ReleaseAction::Major)
+        } else if minor_count > 0 {
+            Some(ReleaseAction::Minor)
+        } else if patch_count > 0 {
+            Some(ReleaseAction::Patch)
+        } else {
+            None
+        }
+    }
+}
+
+pub trait CommitHandler {
+    fn get_messages_from_last_tag(&self) -> MessagesToAnalyze;
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/sleppa_commit_analyzer/src/repositories/errors.rs
+++ b/crates/sleppa_commit_analyzer/src/repositories/errors.rs
@@ -1,9 +1,9 @@
-/// Error enumeration for the `repositories` module.
+/// Enumerates errors that could occur when working with repositories.
 ///
 /// This list is a central structure aiming to define errors that can occur
 /// while processing with repositories.
 #[derive(thiserror::Error, Debug)]
-pub enum RepositoriesError {
+pub enum RepositoryError {
     // Chained errors occuring when processing with GitHub
     #[error(transparent)]
     GithubError(#[from] octocrab::GitHubError),
@@ -26,4 +26,4 @@ pub enum RepositoriesError {
 }
 
 /// Definition of the commit analyzer result
-pub type RepositoriesResult<R> = Result<R, RepositoriesError>;
+pub type RepositoryResult<R> = Result<R, RepositoryError>;

--- a/crates/sleppa_commit_analyzer/src/repositories/errors.rs
+++ b/crates/sleppa_commit_analyzer/src/repositories/errors.rs
@@ -1,0 +1,29 @@
+/// Error enumeration for the `repositories` module.
+///
+/// This list is a central structure aiming to define errors that can occur
+/// while processing with repositories.
+#[derive(thiserror::Error, Debug)]
+pub enum RepositoriesError {
+    // Chained errors occuring when processing with GitHub
+    #[error(transparent)]
+    GithubError(#[from] octocrab::GitHubError),
+
+    // Chained errors occuring when processing with octocrab's API
+    #[error(transparent)]
+    ApiError(#[from] octocrab::Error),
+
+    // Chained errors occurring when processing regular expressions
+    #[error(transparent)]
+    RegexError(#[from] regex::Error),
+
+    // Chained errors occurring when parsing an integer
+    #[error(transparent)]
+    ParsingError(#[from] std::num::ParseIntError),
+
+    // Message is not correct
+    #[error("Pull request name is incorrect : {0}")]
+    InvalidMessage(String),
+}
+
+/// Definition of the commit analyzer result
+pub type RepositoriesResult<R> = Result<R, RepositoriesError>;

--- a/crates/sleppa_commit_analyzer/src/repositories/github.rs
+++ b/crates/sleppa_commit_analyzer/src/repositories/github.rs
@@ -1,0 +1,192 @@
+//! API used to communicate with GitHub.
+//!
+//! The [octocrab] crate is used to retrieve pull request, their inner commits and the tag since the last release
+//! from a GitHub repository.
+//!
+//! The semantic API of octocrab is used when possible. However the HTTP API is used to retrieve the pull request's
+//! inner commit as this request is not implemented by the semantic API.
+//!
+//! Octocrab semantic API uses `Builder` structures. The listing builder returns [octocrab::Page].
+//! A Page contains the items in a \[Page::item\] field.
+//!
+//! The pull requests are [RepoCommit] structure. It contains a field \[RepoCommit::commit\] where the message is
+//! stored inside a [octocrab::models::repos::RepoCommitPage] structure along with other fields.
+//!
+//! The inner commit's are [RepoCommit] structure as well.
+//!
+//! To disambiguate, in octocrab a [octocrab::models::pulls::PullRequest] is a pull request item which state can be
+//! opened or closed.
+//! Once the pull request has been merged to a branch, it is available as a [RepoCommit] with its own properties like
+//! message and hash.
+
+use async_trait::async_trait;
+use octocrab::models::repos::RepoCommit;
+use regex::Regex;
+
+use super::{
+    errors::{RepositoriesError, RepositoriesResult},
+    RepoTag, Repository,
+};
+
+/// Represents a minimal GitHub repository
+///
+/// A GitHub repository comes with 2 parameters at least :
+/// - an owner
+/// - a name
+///
+/// The path is then like `/repos/{owner}/{name}/` for the GitHub's API
+#[derive(Default, Debug)]
+pub struct GithubRepository {
+    /// Represents the owner
+    pub owner: String,
+    /// Represents the name of the repository
+    pub repo: String,
+}
+
+#[async_trait]
+impl Repository for GithubRepository {
+    /// Get the reposiroty's last tag and its sha
+    ///
+    /// If the repository has no tag yet, an empty one is created.
+    /// Else the repository's tag is used to create a new [RepoTag].
+    ///
+    /// The octocrab semantic API returns a [octocrab::Page] of [octocrab::Tag].
+    async fn get_last_tag(&self) -> RepositoriesResult<RepoTag> {
+        // Get all the tag of a repository.
+        let page_tags = octocrab::instance()
+            .repos(&self.owner, &self.repo)
+            .list_tags()
+            .send()
+            .await?;
+
+        if page_tags.items.is_empty() {
+            // Creates an empty [RepoTag] if no tag is found.
+            let last_tag = RepoTag {
+                tag_id: "".to_string(),
+                tag_hash: "".to_string(),
+            };
+            Ok(last_tag)
+        } else {
+            // Creates a [RepoTag] with the tag found.
+            let last_tag = &page_tags.items[0];
+            Ok(RepoTag {
+                tag_id: last_tag.name.to_string(),
+                tag_hash: last_tag.commit.sha.to_string(),
+            })
+        }
+    }
+
+    /// Get inner commit's messages since the last tag
+    ///
+    /// From a repository's name and owner, all the inner commits' messages since the last tag are retrieved.
+    /// If no tag is found, all the [RepoCommit] are analyzed.
+    /// If the name of the pull request is malformed, it is then ignored.
+    async fn get_inner_commits_messages(&self) -> RepositoriesResult<Vec<String>> {
+        let mut inner_commits_messages: Vec<String> = vec![];
+
+        // Get the repository's tag.
+        let tag = self.get_last_tag().await?;
+
+        // Get the repository's pull request from the tag.
+        let repo_commits = self.get_pull_request(&tag.tag_hash).await?;
+
+        // Extracts the pull request's number from its name.
+        // If the pull request's name is malformed, the procces ignores it.
+        for name in repo_commits {
+            let pr_number = match GithubRepository::get_pull_request_number_from_its_name(&name) {
+                Ok(pr_number) => pr_number, // Get the pull request's number
+                Err(_err) => continue,      // Ignore malformed pull request's name
+            };
+
+            // Get the inner commits from the pull request's number found previously
+            let inner_commits = self.get_inner_commits_from_pull_request(pr_number).await?;
+
+            // Pushes inner commit's messages to the result array
+            for commit in inner_commits {
+                inner_commits_messages.push(commit.commit.message.to_string());
+            }
+        }
+        Ok(inner_commits_messages)
+    }
+}
+
+impl GithubRepository {
+    /// Get the pull request's message
+    ///
+    /// In a squash-and-merge strategy, the merged commits are pull-request. Therefore their name
+    /// must be well formed e.g. "Issue to solve (#2)" in order to retrieve their number.
+    ///
+    /// The octocrab Semantic API returns a [octocrab::Page] of [RepoCommit].
+    pub async fn get_pull_request(&self, tag_sha: &str) -> RepositoriesResult<Vec<String>> {
+        let repo_commits = octocrab::instance()
+            .repos(&self.owner, &self.repo)
+            .list_commits()
+            .send()
+            .await?;
+
+        let mut pull_request_messages: Vec<String> = vec![];
+
+        if tag_sha.is_empty() {
+            // Retrieves all the repository commit of a repository if there is no tag
+            for item in repo_commits.items {
+                pull_request_messages.push(item.commit.message.to_string())
+            }
+        } else {
+            // If a tag is found, only the repository commits until this tag are retrieved
+            for item in repo_commits.items {
+                if item.sha != tag_sha {
+                    println!("item: {:?}, {:?}", item.sha, item.commit.message);
+                    pull_request_messages.push(item.commit.message.to_string())
+                } else {
+                    break;
+                }
+            }
+        }
+
+        Ok(pull_request_messages)
+    }
+
+    /// Get the pull request's number from its name
+    ///
+    /// In a squash-and-merge strategy, the merged pull request must have a name well formed like `Issue to solve (#6)`
+    /// where `6` indicates the pull request's number. That number is retrieved by this function using a regex format.
+    pub fn get_pull_request_number_from_its_name(pull_request_name: &str) -> RepositoriesResult<u64> {
+        // Creates the regex expression for the pull request's name grammar e.g. `Issue to solve (#5)`.
+        let regex = Regex::new(r"\(\#(?P<number>[0-9]+)\)$")?;
+
+        // Verifies if the grammar matches the pull request's name
+        let captured = match regex.captures(pull_request_name) {
+            Some(captured) => captured,
+            None => return Err(RepositoriesError::InvalidMessage("Fails to match regex".to_string())),
+        };
+
+        // Get the captured group `number` to get the pull request's number
+        let pr_number = match captured.name("number") {
+            Some(number) => number,
+            None => {
+                return Err(RepositoriesError::InvalidMessage(
+                    "Fails to captured the group".to_string(),
+                ))
+            }
+        };
+
+        // Parses the string slice to an u64
+        match pr_number.as_str().parse::<u64>() {
+            Ok(number) => Ok(number),
+            Err(err) => Err(RepositoriesError::ParsingError(err)),
+        }
+    }
+
+    /// Get pull request's inner commits
+    ///
+    /// From the pull request's number, its inner commits are retrieved thanks to [octocrab] HTTP API.
+    /// The inner commit's of a pull request are [RepoCommit] in octocrab.
+    pub async fn get_inner_commits_from_pull_request(&self, pr_number: u64) -> RepositoriesResult<Vec<RepoCommit>> {
+        // Format the route to the repository
+        let repo_address = format! {"/repos/{}/{}/pulls/{2}/commits", &self.owner, &self.repo, pr_number};
+
+        // Retrieve the inner commits with the octocrab HTTP API
+        let commits = octocrab::instance().get(repo_address, None::<&()>).await?;
+        Ok(commits)
+    }
+}

--- a/crates/sleppa_commit_analyzer/src/repositories/github.rs
+++ b/crates/sleppa_commit_analyzer/src/repositories/github.rs
@@ -111,7 +111,7 @@ impl Repository for GithubRepository {
 }
 
 impl GithubRepository {
-    /// Get the pull request's message
+    /// Get the pull request's name
     ///
     /// In a squash-and-merge strategy, the merged commits are pull-request. Therefore their name
     /// must be well formed e.g. "Issue to solve (#2)" in order to retrieve their number.
@@ -135,7 +135,6 @@ impl GithubRepository {
             // If a tag is found, only the repository commits until this tag are retrieved
             for item in repo_commits.items {
                 if item.sha != tag_sha {
-                    println!("item: {:?}, {:?}", item.sha, item.commit.message);
                     pull_request_messages.push(item.commit.message.to_string())
                 } else {
                     break;
@@ -183,7 +182,7 @@ impl GithubRepository {
     /// The inner commit's of a pull request are [RepoCommit] in octocrab.
     pub async fn get_inner_commits_from_pull_request(&self, pr_number: u64) -> RepositoriesResult<Vec<RepoCommit>> {
         // Format the route to the repository
-        let repo_address = format! {"/repos/{}/{}/pulls/{2}/commits", &self.owner, &self.repo, pr_number};
+        let repo_address = format! {"/repos/{}/{}/pulls/{}/commits", &self.owner, &self.repo, pr_number};
 
         // Retrieve the inner commits with the octocrab HTTP API
         let commits = octocrab::instance().get(repo_address, None::<&()>).await?;

--- a/crates/sleppa_commit_analyzer/src/repositories/github.rs
+++ b/crates/sleppa_commit_analyzer/src/repositories/github.rs
@@ -1,13 +1,15 @@
-//! API used to communicate with GitHub.
+//! Wrapper around GitHub API
 //!
-//! The [octocrab] crate is used to retrieve pull request, their inner commits and the tag since the last release
+//! [Octocrab](https://crates.io/crates/octocrab) crate is used to retrieve pull requests, their inner commits and the tag since the last release
 //! from a GitHub repository.
 //!
 //! The semantic API of octocrab is used when possible. However the HTTP API is used to retrieve the pull request's
 //! inner commit as this request is not implemented by the semantic API.
 //!
-//! Octocrab semantic API uses `Builder` structures. The listing builder returns [octocrab::Page].
-//! A Page contains the items in a \[Page::item\] field.
+//! Octocrab semantic API are built as `Builder` structures using methods with multiple optionnal parameters e.g. :
+//! `let mut page = octocrab::instance().issues("octocrab", "repo").list().creator("octocrab").per_page(50).send().await?;`
+//!
+//! This builder returns a listing represented as [octocrab::Page] structure.
 //!
 //! The pull requests are [RepoCommit] structure. It contains a field \[RepoCommit::commit\] where the message is
 //! stored inside a [octocrab::models::repos::RepoCommitPage] structure along with other fields.
@@ -24,13 +26,13 @@ use octocrab::models::repos::RepoCommit;
 use regex::Regex;
 
 use super::{
-    errors::{RepositoriesError, RepositoriesResult},
-    RepoTag, Repository,
+    errors::{RepositoryError, RepositoryResult},
+    Repository, RepositoryTag,
 };
 
-/// Represents a minimal GitHub repository
+/// A minimal GitHub repository structure
 ///
-/// A GitHub repository comes with 2 parameters at least :
+/// A GitHub repository comes with at least two parameters, namely:
 /// - an owner
 /// - a name
 ///
@@ -51,7 +53,7 @@ impl Repository for GithubRepository {
     /// Else the repository's tag is used to create a new [RepoTag].
     ///
     /// The octocrab semantic API returns a [octocrab::Page] of [octocrab::Tag].
-    async fn get_last_tag(&self) -> RepositoriesResult<RepoTag> {
+    async fn get_last_tag(&self) -> RepositoryResult<RepositoryTag> {
         // Get all the tag of a repository.
         let page_tags = octocrab::instance()
             .repos(&self.owner, &self.repo)
@@ -61,34 +63,34 @@ impl Repository for GithubRepository {
 
         if page_tags.items.is_empty() {
             // Creates an empty [RepoTag] if no tag is found.
-            let last_tag = RepoTag {
-                tag_id: "".to_string(),
-                tag_hash: "".to_string(),
+            let last_tag = RepositoryTag {
+                identifier: "".to_string(),
+                hash: "".to_string(),
             };
             Ok(last_tag)
         } else {
             // Creates a [RepoTag] with the tag found.
             let last_tag = &page_tags.items[0];
-            Ok(RepoTag {
-                tag_id: last_tag.name.to_string(),
-                tag_hash: last_tag.commit.sha.to_string(),
+            Ok(RepositoryTag {
+                identifier: last_tag.name.to_string(),
+                hash: last_tag.commit.sha.to_string(),
             })
         }
     }
 
-    /// Get inner commit's messages since the last tag
+    /// Get inner commit messages since the last tag
     ///
     /// From a repository's name and owner, all the inner commits' messages since the last tag are retrieved.
     /// If no tag is found, all the [RepoCommit] are analyzed.
     /// If the name of the pull request is malformed, it is then ignored.
-    async fn get_inner_commits_messages(&self) -> RepositoriesResult<Vec<String>> {
+    async fn get_inner_commits(&self) -> RepositoryResult<Vec<String>> {
         let mut inner_commits_messages: Vec<String> = vec![];
 
         // Get the repository's tag.
         let tag = self.get_last_tag().await?;
 
         // Get the repository's pull request from the tag.
-        let repo_commits = self.get_pull_request(&tag.tag_hash).await?;
+        let repo_commits = self.get_pull_request(&tag.hash).await?;
 
         // Extracts the pull request's number from its name.
         // If the pull request's name is malformed, the procces ignores it.
@@ -101,7 +103,7 @@ impl Repository for GithubRepository {
             // Get the inner commits from the pull request's number found previously
             let inner_commits = self.get_inner_commits_from_pull_request(pr_number).await?;
 
-            // Pushes inner commit's messages to the result array
+            // Pushes inner commit messages to the result array
             for commit in inner_commits {
                 inner_commits_messages.push(commit.commit.message.to_string());
             }
@@ -117,7 +119,7 @@ impl GithubRepository {
     /// must be well formed e.g. "Issue to solve (#2)" in order to retrieve their number.
     ///
     /// The octocrab Semantic API returns a [octocrab::Page] of [RepoCommit].
-    pub async fn get_pull_request(&self, tag_sha: &str) -> RepositoriesResult<Vec<String>> {
+    pub async fn get_pull_request(&self, tag_sha: &str) -> RepositoryResult<Vec<String>> {
         let repo_commits = octocrab::instance()
             .repos(&self.owner, &self.repo)
             .list_commits()
@@ -149,21 +151,21 @@ impl GithubRepository {
     ///
     /// In a squash-and-merge strategy, the merged pull request must have a name well formed like `Issue to solve (#6)`
     /// where `6` indicates the pull request's number. That number is retrieved by this function using a regex format.
-    pub fn get_pull_request_number_from_its_name(pull_request_name: &str) -> RepositoriesResult<u64> {
+    pub fn get_pull_request_number_from_its_name(pull_request_name: &str) -> RepositoryResult<u64> {
         // Creates the regex expression for the pull request's name grammar e.g. `Issue to solve (#5)`.
         let regex = Regex::new(r"\(\#(?P<number>[0-9]+)\)$")?;
 
         // Verifies if the grammar matches the pull request's name
         let captured = match regex.captures(pull_request_name) {
             Some(captured) => captured,
-            None => return Err(RepositoriesError::InvalidMessage("Fails to match regex".to_string())),
+            None => return Err(RepositoryError::InvalidMessage("Fails to match regex".to_string())),
         };
 
         // Get the captured group `number` to get the pull request's number
         let pr_number = match captured.name("number") {
             Some(number) => number,
             None => {
-                return Err(RepositoriesError::InvalidMessage(
+                return Err(RepositoryError::InvalidMessage(
                     "Fails to captured the group".to_string(),
                 ))
             }
@@ -172,15 +174,15 @@ impl GithubRepository {
         // Parses the string slice to an u64
         match pr_number.as_str().parse::<u64>() {
             Ok(number) => Ok(number),
-            Err(err) => Err(RepositoriesError::ParsingError(err)),
+            Err(err) => Err(RepositoryError::ParsingError(err)),
         }
     }
 
     /// Get pull request's inner commits
     ///
     /// From the pull request's number, its inner commits are retrieved thanks to [octocrab] HTTP API.
-    /// The inner commit's of a pull request are [RepoCommit] in octocrab.
-    pub async fn get_inner_commits_from_pull_request(&self, pr_number: u64) -> RepositoriesResult<Vec<RepoCommit>> {
+    /// The inner commit of a pull request are [RepoCommit] in octocrab.
+    pub async fn get_inner_commits_from_pull_request(&self, pr_number: u64) -> RepositoryResult<Vec<RepoCommit>> {
         // Format the route to the repository
         let repo_address = format! {"/repos/{}/{}/pulls/{}/commits", &self.owner, &self.repo, pr_number};
 

--- a/crates/sleppa_commit_analyzer/src/repositories/mod.rs
+++ b/crates/sleppa_commit_analyzer/src/repositories/mod.rs
@@ -1,26 +1,42 @@
+//! This module defines the interface between the `sleppa_commit_analyzer` crate and the distributed version control system,
+//! namely git.
+//!
+//! To be agnostic to the git system, the trait `Repository` defines the shared behavior to implement to use
+//! sleppa_commit_analyzer.
+//!
+//! Moreover, a shared structure [RepositoryTag] defines the tag of a git repository system with its two basic property,
+//! namely the identifier (e.g. `v3.2.1`) and the associated hash.
+//!
+//! In order to operate, `sleppa_commit_analyzer` needs the last tag of a repository and the commit messages since this last
+//! tag.
+
 pub mod errors;
 pub mod github;
 
 use async_trait::async_trait;
-use errors::RepositoriesResult;
+use errors::RepositoryResult;
 
 /// Definition of a repository's tag.
-pub struct RepoTag {
+pub struct RepositoryTag {
     /// Value of the tag e.g. `v3.2.1`.
-    pub tag_id: String,
+    pub identifier: String,
     /// Hash of the tag.
-    pub tag_hash: String,
+    pub hash: String,
 }
 
+/// Trait to interface the git system used with `sleppa_commit_analyzer`.
+///
+/// `sleppa_commit_analyzer` needs the inner commit messages and the last tag to retrieve the
+/// [ReleaseAction].
 #[async_trait]
 pub trait Repository {
     /// Get the repository's last tag and its sha.
     ///
     /// The output is used later to process the new tag.
-    async fn get_last_tag(&self) -> RepositoriesResult<RepoTag>;
+    async fn get_last_tag(&self) -> RepositoryResult<RepositoryTag>;
 
-    /// Get inner commit's messages since the last tag.
+    /// Get inner commit messages since the last tag.
     ///
     /// The output is analyzed by the commit analyzer to define the release action type.
-    async fn get_inner_commits_messages(&self) -> RepositoriesResult<Vec<String>>;
+    async fn get_inner_commits(&self) -> RepositoryResult<Vec<String>>;
 }

--- a/crates/sleppa_commit_analyzer/src/repositories/mod.rs
+++ b/crates/sleppa_commit_analyzer/src/repositories/mod.rs
@@ -1,0 +1,26 @@
+pub mod errors;
+pub mod github;
+
+use async_trait::async_trait;
+use errors::RepositoriesResult;
+
+/// Definition of a repository's tag.
+pub struct RepoTag {
+    /// Value of the tag e.g. `v3.2.1`.
+    pub tag_id: String,
+    /// Hash of the tag.
+    pub tag_hash: String,
+}
+
+#[async_trait]
+pub trait Repository {
+    /// Get the repository's last tag and its sha.
+    ///
+    /// The output is used later to process the new tag.
+    async fn get_last_tag(&self) -> RepositoriesResult<RepoTag>;
+
+    /// Get inner commit's messages since the last tag.
+    ///
+    /// The output is analyzed by the commit analyzer to define the release action type.
+    async fn get_inner_commits_messages(&self) -> RepositoriesResult<Vec<String>>;
+}

--- a/crates/sleppa_commit_analyzer/src/tests.rs
+++ b/crates/sleppa_commit_analyzer/src/tests.rs
@@ -1,0 +1,118 @@
+//! Unit tests
+//!
+//! This testing module implements the unit tests for testing the commit analyzer routines.
+
+use super::*;
+
+#[test]
+/// Tests the function `execute`.
+fn test_can_execute() {
+    // Unit test preparation
+    // Builds a correct [Configuration] structure for testing purpose.
+    let mut config: Configuration = Configuration::new();
+    config.release_rules.insert(
+        ReleaseAction::Major,
+        ReleaseRule {
+            format: ReleaseRuleFormat::Regex,
+            grammar: r"^(break){1}(\(\S.*\S\))?:\s.*[a-z0-9]$".to_string(),
+        },
+    );
+    config.release_rules.insert(
+        ReleaseAction::Minor,
+        ReleaseRule {
+            format: ReleaseRuleFormat::Regex,
+            grammar: r"^(feat){1}(\(\S.*\S\))?:\s.*[a-z0-9]$".to_string(),
+        },
+    );
+    config.release_rules.insert(
+        ReleaseAction::Patch,
+        ReleaseRule {
+            format: ReleaseRuleFormat::Regex,
+            grammar: r"^(refac){1}(\(\S.*\S\))?:\s.*[a-z0-9]$".to_string(),
+        },
+    );
+
+    // Creates correct messages for the grammar defined above
+    let msg0 = "break: add a function";
+    let msg1 = "refac: some ref";
+
+    // Creates incorrect messages for the grammar defined above
+    // "ci" doesn't refer to a release action type
+    let msg2 = "ci: some change";
+    // No semi-column after the type
+    let msg3 = "feat introduced new function";
+
+    // Execution step
+    let ca = CommitAnalyzer::default();
+
+    // Asserts the results of the function match the correct ReleaseAction
+    assert_eq!(ca.execute(msg0, &config.release_rules).unwrap(), ReleaseAction::Major);
+    assert_eq!(ca.execute(msg1, &config.release_rules).unwrap(), ReleaseAction::Patch);
+
+    // Asserts the results of the function are incorrect.
+    assert!(ca.execute(msg2, &config.release_rules).is_err());
+    assert!(ca.execute(msg3, &config.release_rules).is_err());
+}
+
+#[test]
+/// Tests the function `action_to_release`.
+fn test_can_action_to_release() {
+    // Unit test preparation
+    // Builds a correct [Configuration] structure testing purpose.
+    let mut config: Configuration = Configuration::new();
+    config.release_rules.insert(
+        ReleaseAction::Major,
+        ReleaseRule {
+            format: ReleaseRuleFormat::Regex,
+            grammar: r"^(break){1}(\(\S.*\S\))?:\s.*[a-z0-9]$".to_string(),
+        },
+    );
+    config.release_rules.insert(
+        ReleaseAction::Minor,
+        ReleaseRule {
+            format: ReleaseRuleFormat::Regex,
+            grammar: r"^(feat){1}(\(\S.*\S\))?:\s.*[a-z0-9]$".to_string(),
+        },
+    );
+    config.release_rules.insert(
+        ReleaseAction::Patch,
+        ReleaseRule {
+            format: ReleaseRuleFormat::Regex,
+            grammar: r"^(refac){1}(\(\S.*\S\))?:\s.*[a-z0-9]$".to_string(),
+        },
+    );
+
+    // Creates [MessageToAnalyze] structures
+    let messages1 = vec![
+        "break: add a function".to_string(),
+        "refac: some ref".to_string(),
+        "ci: some change".to_string(),
+        "feat: a cool feature".to_string(),
+    ];
+
+    let messages2 = vec![
+        "refac: documentation".to_string(),
+        "refac: some ref".to_string(),
+        "ci: some change".to_string(),
+    ];
+
+    let messages3: Vec<String> = vec![];
+
+    let mes1 = MessagesToAnalyze { messages: messages1 };
+    let mes2 = MessagesToAnalyze { messages: messages2 };
+    let mes3 = MessagesToAnalyze { messages: messages3 };
+
+    // Execution step
+    let ca = CommitAnalyzer::default();
+
+    // Asserts the results of the function match the correct ReleaseAction
+    assert_eq!(
+        ca.action_to_release(mes1, &config.release_rules).unwrap(),
+        ReleaseAction::Major
+    );
+    assert_eq!(
+        ca.action_to_release(mes2, &config.release_rules).unwrap(),
+        ReleaseAction::Patch
+    );
+    assert!(ca.action_to_release(mes3, &config.release_rules).is_none());
+}

--- a/crates/sleppa_commit_analyzer/src/tests.rs
+++ b/crates/sleppa_commit_analyzer/src/tests.rs
@@ -2,13 +2,19 @@
 //!
 //! This testing module implements the unit tests for testing the commit analyzer routines.
 
-use super::repositories::{github::GithubRepository, Repository};
-use super::*;
+use super::{
+    repositories::{github::*, Repository},
+    *,
+};
+//{
+//    repositories::{github::GithubRepository, Repository},
+//    *,
+//};
 
-/// Tests the function `execute`.
-///
-/// The `execute` function must return a [ReleaseAction] if the message matches the defined regex.
-/// A [CommitAnalyzerError] is returned if no matches.
+// Tests the function `execute`.
+//
+// The `execute` function must return a [ReleaseAction] if the message matches the defined regex.
+// A [CommitAnalyzerError] is returned if no matches.
 #[test]
 fn test_can_execute() {
     // Unit test preparation
@@ -72,11 +78,11 @@ fn test_can_execute() {
         .is_err());
 }
 
-/// Tests the function `analyze`.
-///
-/// The `analyze` function analyzes multiple messages and return the highest
-/// [ReleaseAction] found from them.
-/// If a ReleaseAction is not found, a `None` is returned.
+// Tests the function `analyze`.
+//
+// The `analyze` function analyzes multiple messages and return the highest
+// [ReleaseAction] found from them.
+// If a ReleaseAction is not found, a `None` is returned.
 #[test]
 fn test_can_analyze() {
     // Unit test preparation
@@ -139,10 +145,10 @@ fn test_can_analyze() {
     assert!(analyzer.analyze(correct_no_release, &config.release_rules).is_none());
 }
 
-/// Tests the function `get_pull_request_number_from_its_name`.
-///
-/// This function analyzes the name of a pull request and retrieve its number as u64.
-/// If none is found a [RepositoriesError] is returned.
+// Tests the function `get_pull_request_number_from_its_name`.
+//
+// This function analyzes the name of a pull request and retrieve its number as u64.
+// If none is found a [RepositoriesError] is returned.
 #[test]
 fn test_can_get_pull_request_number_from_its_name() {
     // Unit test preparation
@@ -168,12 +174,12 @@ fn test_can_get_pull_request_number_from_its_name() {
     assert!(GithubRepository::get_pull_request_number_from_its_name(incorrect_no_hashtag).is_err());
 }
 
-/// Tests the function `get_last_tag`.
-///
-/// This function retrieves the last tag of a repository. As it works with [octocrab], the http request
-/// is automatically sent to GitHub. Therefore a [semantic release testbed](https://github.com/SofairOfficial/semantic-release-squash-and-merge-testbed)
-/// repository has been created.
-/// The tag of this repo is "v1.0.0" and its associated hash : "cd2fe77015b7aa2ac666ec05e14b76c9ba3dfd0a"
+// Tests the function `get_last_tag`.
+//
+// This function retrieves the last tag of a repository. As it works with [octocrab], the http request
+// is automatically sent to GitHub. Therefore a [semantic release testbed](https://github.com/SofairOfficial/semantic-release-squash-and-merge-testbed)
+// repository has been created.
+// The tag of this repo is "v1.0.0" and its associated hash : "cd2fe77015b7aa2ac666ec05e14b76c9ba3dfd0a"
 #[tokio::test]
 async fn test_can_get_last_tag() -> TestResult<()> {
     // Unit test preparation
@@ -187,23 +193,23 @@ async fn test_can_get_last_tag() -> TestResult<()> {
     let response = githubrepository.get_last_tag().await?;
 
     // Asserts the name of the tag and its hash are ok.
-    assert_eq!(response.tag_id, "v1.0.0");
-    assert_eq!(response.tag_hash, "cd2fe77015b7aa2ac666ec05e14b76c9ba3dfd0a");
+    assert_eq!(response.identifier, "v1.0.0");
+    assert_eq!(response.hash, "cd2fe77015b7aa2ac666ec05e14b76c9ba3dfd0a");
     Ok(())
 }
 
-/// Tests the function `get_pull_request`.
-///
-/// This function retrieves the pull request since a tag. As it works with [octocrab], the http request
-/// is automatically sent to GitHub. Therefore a [semantic release testbed](https://github.com/SofairOfficial/semantic-release-squash-and-merge-testbed)
-/// repository has been created.
-/// The tag of this repo is "v1.0.0" and its associated hash : "cd2fe77015b7aa2ac666ec05e14b76c9ba3dfd0a"
-/// 3 pull requests have been done on the repository :
-///  - Issue-to-solve-3
-///  - Issue-to-solve-2 (#2)
-///  - Issue-to-solve-1 (#1)
-///
-/// As the `Issue-to-solve-1 (#1)` is linked to the last tag, it will be ignored.
+// Tests the function `get_pull_request`.
+//
+// This function retrieves the pull request since a tag. As it works with [octocrab], the http request
+// is automatically sent to GitHub. Therefore a [semantic release testbed](https://github.com/SofairOfficial/semantic-release-squash-and-merge-testbed)
+// repository has been created.
+// The tag of this repo is "v1.0.0" and its associated hash : "cd2fe77015b7aa2ac666ec05e14b76c9ba3dfd0a"
+// 3 pull requests have been done on the repository :
+//  - Issue-to-solve-3
+//  - Issue-to-solve-2 (#2)
+//  - Issue-to-solve-1 (#1)
+//
+// As the `Issue-to-solve-1 (#1)` is linked to the last tag, it will be ignored.
 #[tokio::test]
 async fn test_can_get_pull_request() -> TestResult<()> {
     // Unit test preparation
@@ -224,13 +230,13 @@ async fn test_can_get_pull_request() -> TestResult<()> {
     Ok(())
 }
 
-/// Tests the function `get_inner_commits_from_pull_request`.
-///
-/// This function retrieves the pull request's inner commits from a pull request number. As it works with [octocrab],
-/// the http request is automatically sent to GitHub. Therefore a [semantic release testbed](https://github.com/SofairOfficial/semantic-release-squash-and-merge-testbed)
-/// repository has been created.
-/// The last valid pull request number comes from the name "Issue-to-solve-2 (#2)", hence the pull request's number to
-/// analyze is `2`.
+// Tests the function `get_inner_commits_from_pull_request`.
+//
+// This function retrieves the pull request's inner commits from a pull request number. As it works with [octocrab],
+// the http request is automatically sent to GitHub. Therefore a [semantic release testbed](https://github.com/SofairOfficial/semantic-release-squash-and-merge-testbed)
+// repository has been created.
+// The last valid pull request number comes from the name "Issue-to-solve-2 (#2)", hence the pull request's number to
+// analyze is `2`.
 #[tokio::test]
 async fn test_can_get_inner_commits_from_pull_request() -> TestResult<()> {
     // Unit test preparation
@@ -254,13 +260,13 @@ async fn test_can_get_inner_commits_from_pull_request() -> TestResult<()> {
     Ok(())
 }
 
-/// Tests the function `get_inner_commits_messages`.
-///
-/// This function retrieves the pull request's inner commits message from a repository. As it works with [octocrab],
-/// the http request is automatically sent to GitHub. Therefore a [semantic release testbed](https://github.com/SofairOfficial/semantic-release-squash-and-merge-testbed)
-/// repository has been created.
-/// The function retrieves the last tag (`v1.0.0`), get the pull requests since this tag, analyzes their name, extracts the
-/// pull request number and retrieves all the inner commit's messages.
+// Tests the function `get_inner_commits_messages`.
+//
+// This function retrieves the pull request's inner commits message from a repository. As it works with [octocrab],
+// the http request is automatically sent to GitHub. Therefore a [semantic release testbed](https://github.com/SofairOfficial/semantic-release-squash-and-merge-testbed)
+// repository has been created.
+// The function retrieves the last tag (`v1.0.0`), get the pull requests since this tag, analyzes their name, extracts the
+// pull request number and retrieves all the inner commit messages.
 #[tokio::test]
 async fn test_can_get_inner_commits_messages() -> TestResult<()> {
     let githubrepository = GithubRepository {
@@ -269,7 +275,7 @@ async fn test_can_get_inner_commits_messages() -> TestResult<()> {
     };
 
     // Execution step
-    let response = githubrepository.get_inner_commits_messages().await?;
+    let response = githubrepository.get_inner_commits().await?;
 
     // Asserts the name of retrived pull request are corrects.
     assert_eq!(response[0], "patch:some patch");
@@ -279,5 +285,5 @@ async fn test_can_get_inner_commits_messages() -> TestResult<()> {
     Ok(())
 }
 
-/// Unit test result type
+// Unit test result type
 pub type TestResult<T> = std::result::Result<T, Box<dyn std::error::Error>>;

--- a/crates/sleppa_commit_analyzer/src/tests.rs
+++ b/crates/sleppa_commit_analyzer/src/tests.rs
@@ -2,12 +2,13 @@
 //!
 //! This testing module implements the unit tests for testing the commit analyzer routines.
 
+use super::repositories::{github::GithubRepository, Repository};
 use super::*;
 
 /// Tests the function `execute`.
 ///
-/// The `execute` function must return a ReleaseAction if the message matches the defined regex.
-/// However a CommitAnalyzerError is returned if no matches.
+/// The `execute` function must return a [ReleaseAction] if the message matches the defined regex.
+/// A [CommitAnalyzerError] is returned if no matches.
 #[test]
 fn test_can_execute() {
     // Unit test preparation
@@ -62,7 +63,7 @@ fn test_can_execute() {
         ReleaseAction::Patch
     );
 
-    // Asserts the results of the function are incorrect.
+    // Asserts the results of the function are incorrects.
     assert!(analyzer
         .execute(incorrect_message_ci_not_match, &config.release_rules)
         .is_err());
@@ -74,12 +75,12 @@ fn test_can_execute() {
 /// Tests the function `analyze`.
 ///
 /// The `analyze` function analyzes multiple messages and return the highest
-/// ReleaseAction found from them.
+/// [ReleaseAction] found from them.
 /// If a ReleaseAction is not found, a `None` is returned.
 #[test]
-fn test_can_aanalyze() {
+fn test_can_analyze() {
     // Unit test preparation
-    // Builds a correct [Configuration] structure testing purpose.
+    // Builds a correct [Configuration] structure for testing purpose.
     let mut config: Configuration = Configuration::new();
     config.release_rules.insert(
         ReleaseAction::Major,
@@ -103,7 +104,7 @@ fn test_can_aanalyze() {
         },
     );
 
-    // Creates arrys of strings
+    // Creates arrays of strings
     let correct_messages_major_release = vec![
         "break: add a function".to_string(),
         "refac: some ref".to_string(),
@@ -137,3 +138,146 @@ fn test_can_aanalyze() {
     );
     assert!(analyzer.analyze(correct_no_release, &config.release_rules).is_none());
 }
+
+/// Tests the function `get_pull_request_number_from_its_name`.
+///
+/// This function analyzes the name of a pull request and retrieve its number as u64.
+/// If none is found a [RepositoriesError] is returned.
+#[test]
+fn test_can_get_pull_request_number_from_its_name() {
+    // Unit test preparation
+    // Builds a correct pull request's name.
+    let correct_pr_name = "Issue to solve (#2)";
+
+    // Builds  incorrect pull request's names.
+    // An incorrect space
+    let incorrect_space = "Issue to solve (# 3)";
+    // No parenthesis
+    let incorrect_no_parenthesis = "Issue to solve #3";
+    // No hashtag
+    let incorrect_no_hashtag = "Issue to solve (5)";
+
+    // Asserts the pull request's number is retrieved
+    assert_eq!(
+        GithubRepository::get_pull_request_number_from_its_name(correct_pr_name).unwrap(),
+        2u64
+    );
+    // Asserts an error occurs
+    assert!(GithubRepository::get_pull_request_number_from_its_name(incorrect_space).is_err());
+    assert!(GithubRepository::get_pull_request_number_from_its_name(incorrect_no_parenthesis).is_err());
+    assert!(GithubRepository::get_pull_request_number_from_its_name(incorrect_no_hashtag).is_err());
+}
+
+/// Tests the function `get_last_tag`.
+///
+/// This function retrieves the last tag of a repository. As it works with [octocrab], the http request
+/// is automatically sent to GitHub. Therefore a [semantic release testbed](https://github.com/SofairOfficial/semantic-release-squash-and-merge-testbed)
+/// repository has been created.
+/// The tag of this repo is "v1.0.0" and its associated hash : "cd2fe77015b7aa2ac666ec05e14b76c9ba3dfd0a"
+#[tokio::test]
+async fn test_can_get_last_tag() -> TestResult<()> {
+    // Unit test preparation
+    // Providing the credentials for the test repository.
+    let githubrepository = GithubRepository {
+        repo: "semantic-release-squash-and-merge-testbed".to_string(),
+        owner: "SofairOfficial".to_string(),
+    };
+
+    // Execution step
+    let response = githubrepository.get_last_tag().await?;
+
+    // Asserts the name of the tag and its hash are ok.
+    assert_eq!(response.tag_id, "v1.0.0");
+    assert_eq!(response.tag_hash, "cd2fe77015b7aa2ac666ec05e14b76c9ba3dfd0a");
+    Ok(())
+}
+
+/// Tests the function `get_pull_request`.
+///
+/// This function retrieves the pull request since a tag. As it works with [octocrab], the http request
+/// is automatically sent to GitHub. Therefore a [semantic release testbed](https://github.com/SofairOfficial/semantic-release-squash-and-merge-testbed)
+/// repository has been created.
+/// The tag of this repo is "v1.0.0" and its associated hash : "cd2fe77015b7aa2ac666ec05e14b76c9ba3dfd0a"
+/// 3 pull requests have been done on the repository :
+///  - Issue-to-solve-3
+///  - Issue-to-solve-2 (#2)
+///  - Issue-to-solve-1 (#1)
+///
+/// As the `Issue-to-solve-1 (#1)` is linked to the last tag, it will be ignored.
+#[tokio::test]
+async fn test_can_get_pull_request() -> TestResult<()> {
+    // Unit test preparation
+    // Providing the credentials for the test repository.
+    let githubrepository = GithubRepository {
+        repo: "semantic-release-squash-and-merge-testbed".to_string(),
+        owner: "SofairOfficial".to_string(),
+    };
+    let tag_sha = "cd2fe77015b7aa2ac666ec05e14b76c9ba3dfd0a";
+
+    // Execution step
+    let response = githubrepository.get_pull_request(tag_sha).await?;
+
+    // Asserts the name of retrived pull request are corrects.
+    assert!(response.len() == 2);
+    assert_eq!(response[0], "Issue-to-solve-3");
+    assert_eq!(response[1], "Issue-to-solve-2 (#2)");
+    Ok(())
+}
+
+/// Tests the function `get_inner_commits_from_pull_request`.
+///
+/// This function retrieves the pull request's inner commits from a pull request number. As it works with [octocrab],
+/// the http request is automatically sent to GitHub. Therefore a [semantic release testbed](https://github.com/SofairOfficial/semantic-release-squash-and-merge-testbed)
+/// repository has been created.
+/// The last valid pull request number comes from the name "Issue-to-solve-2 (#2)", hence the pull request's number to
+/// analyze is `2`.
+#[tokio::test]
+async fn test_can_get_inner_commits_from_pull_request() -> TestResult<()> {
+    // Unit test preparation
+    // Providing the credentials for the test repository.
+    let githubrepository = GithubRepository {
+        repo: "semantic-release-squash-and-merge-testbed".to_string(),
+        owner: "SofairOfficial".to_string(),
+    };
+    let pull_request_number = 2u64;
+
+    // Execution step
+    let response = githubrepository
+        .get_inner_commits_from_pull_request(pull_request_number)
+        .await?;
+
+    // Asserts the name of pull request's inner commits are corrects.
+    assert_eq!(response[0].commit.message, "patch:some patch");
+    assert_eq!(response[1].commit.message, "feat(script): add a script");
+    assert_eq!(response[2].commit.message, "feat: add a feature");
+
+    Ok(())
+}
+
+/// Tests the function `get_inner_commits_messages`.
+///
+/// This function retrieves the pull request's inner commits message from a repository. As it works with [octocrab],
+/// the http request is automatically sent to GitHub. Therefore a [semantic release testbed](https://github.com/SofairOfficial/semantic-release-squash-and-merge-testbed)
+/// repository has been created.
+/// The function retrieves the last tag (`v1.0.0`), get the pull requests since this tag, analyzes their name, extracts the
+/// pull request number and retrieves all the inner commit's messages.
+#[tokio::test]
+async fn test_can_get_inner_commits_messages() -> TestResult<()> {
+    let githubrepository = GithubRepository {
+        repo: "semantic-release-squash-and-merge-testbed".to_string(),
+        owner: "SofairOfficial".to_string(),
+    };
+
+    // Execution step
+    let response = githubrepository.get_inner_commits_messages().await?;
+
+    // Asserts the name of retrived pull request are corrects.
+    assert_eq!(response[0], "patch:some patch");
+    assert_eq!(response[1], "feat(script): add a script");
+    assert_eq!(response[2], "feat: add a feature");
+
+    Ok(())
+}
+
+/// Unit test result type
+pub type TestResult<T> = std::result::Result<T, Box<dyn std::error::Error>>;


### PR DESCRIPTION
## Description

This PR implements commit's messages analyzer to retrieve a release action type.

## Related issues

closes #3  

## How has this been tested?

The crate contains unit tests in the file `tests.rs`.

**Test configuration**:
* Firmware version: Ubuntu 22.10
* Hardware: Intel i5-5200U, 4.0GiB RAM
* Toolchain: `Rust cargo test`
* SDK: -

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
