### PR TITLE
Implements plugin to notify new release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ sleppa_changelog = { version = "0.1.0", path = "crates/sleppa_changelog" }
 sleppa_code_archiver = { version = "0.1.0", path = "crates/sleppa_code_archiver" }
 sleppa_commit_analyzer = { version = "0.1.0", path = "crates/sleppa_commit_analyzer" }
 sleppa_configuration = { version = "0.1.0", path = "crates/sleppa_configuration" }
+sleppa_notifier = { version = "0.1.0", path = "crates/sleppa_notifier" }
 sleppa_primitives = { version = "0.1.0", path = "crates/sleppa_primitives" }
 sleppa_versioner = { version = "0.1.0", path = "crates/sleppa_versioner" }
 

--- a/crates/sleppa_notifier/Cargo.toml
+++ b/crates/sleppa_notifier/Cargo.toml
@@ -1,0 +1,47 @@
+[package]
+name = "sleppa_notifier"
+description = "Send a pos to a collaboration platform when a new release is published."
+version = "0.1.0"
+
+keywords = [
+    "Sleppa",
+    "semantic-release",
+    "tag",
+    "version",
+    "release-automation",
+    "release-workflow",
+]
+
+categories = ["Development tools"]
+
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+documentation.workspace = true
+homepage.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+
+# Local dependencies
+sleppa_primitives = { workspace = true }
+sleppa_configuration = { workspace = true }
+
+# External dependencies
+async-trait = { version = "^0.1" }
+reqwest = { version = "0.11.8", features = ["json"] }
+serde = { version = "^1.0", features = ["derive"] }
+serde_json = { version = "^1.0" }
+
+# Errors and logs processing
+thiserror = { workspace = true }
+
+[dev-dependencies]
+tokio = { version = "^1.28", default-features = false, features = ["macros"] }
+tokio-test = { version = "^0.4" }
+
+[lib]
+name = "sleppa_notifier"
+crate-type = ["lib"]
+path = "src/lib.rs"

--- a/crates/sleppa_notifier/src/constants.rs
+++ b/crates/sleppa_notifier/src/constants.rs
@@ -1,0 +1,7 @@
+/// This module regroups all the constants used in the `sleppa_notifier` crate.
+
+/// The key for `sleppa_notifier` in the `Context` to acces sleppa_notifier's `configuration`.
+pub const NOTIFIER_KEY: &str = "sleppa_notifier";
+
+/// The key for `message` in the `Context` to access the new release's message.
+pub const MESSAGE_KEY: &str = "message";

--- a/crates/sleppa_notifier/src/errors.rs
+++ b/crates/sleppa_notifier/src/errors.rs
@@ -1,0 +1,18 @@
+/// Enumerates errors that could occur while notifying a new published release.
+#[derive(thiserror::Error, Debug)]
+pub enum NotifierError {
+    /// No match found when capturing the number with the regex
+    #[error("An error occured: {0}.")]
+    SendingError(String),
+
+    /// Missing key or value in context
+    #[error("Missing key in context: {0}")]
+    InvalidContext(String),
+}
+
+/// Definition of the commit analyzer result
+pub type NotifierResult<R> = Result<R, NotifierError>;
+
+#[cfg(test)]
+/// Result type alias returned by function in unit tests.
+pub type TestResult<T> = std::result::Result<T, Box<dyn std::error::Error>>;

--- a/crates/sleppa_notifier/src/lib.rs
+++ b/crates/sleppa_notifier/src/lib.rs
@@ -1,0 +1,77 @@
+//! Sleppa release notification crate
+//!
+//! This crate aims at notify the team when a new release is publihed by sending a post to a communication platform.
+//! This crate is generic over the platform with the trait [Notify] to implement.
+//!
+//! In order to be generic, this crate provides a trait to define the general behavior. The [Notify] trait is used to
+//! publish a new post on the platform when a new release is published.
+//!
+//! Informations used to send the post are retrieved from a [Context] structure.
+//! This context should contain a [NOTIFIER_KEY] associated with its [Configuration] structure.
+//! This [configuration] should contain a [MESSAGE_KEY] to access the defined message to post.
+
+mod constants;
+mod errors;
+pub mod mattermost;
+
+use async_trait::async_trait;
+use constants::{MESSAGE_KEY, NOTIFIER_KEY};
+use errors::{NotifierError, NotifierResult};
+use sleppa_configuration::{
+    constants::{CONFIGURATION_KEY, CONFIGURATION_LAST_TAG},
+    Context,
+};
+
+/// The plugin used to notify the new release
+#[derive(Default)]
+pub struct NotifierPlugin {
+    /// The message to post for the new release
+    message: String,
+}
+
+/// General behavior to post the message on the plaftorm
+#[async_trait]
+pub trait Notify {
+    /// Sends the notification's post on the platform
+    async fn notify_release(&self, context: &Context, message: String) -> NotifierResult<()>;
+}
+
+impl NotifierPlugin {
+    /// Implementation of the NotifierPlugin::new() method
+    pub fn new() -> Self {
+        NotifierPlugin { message: String::new() }
+    }
+
+    /// Runs the plugin with an existing Context.
+    ///
+    /// The [Context] should contain a [Configuration] key.
+    /// This [Configuration] should also contain the message fot the notification and possibly value needed by the
+    /// used platform to post to.
+    pub async fn run<T>(&mut self, context: &Context, instance: T) -> NotifierResult<()>
+    where
+        T: Notify,
+    {
+        let last_tag = match context.configurations[CONFIGURATION_KEY].map[CONFIGURATION_LAST_TAG].as_tag() {
+            Some(value) => value,
+            None => return Err(NotifierError::InvalidContext("No last tag found.".to_string())),
+        };
+
+        let message = match context.configurations[NOTIFIER_KEY].map[MESSAGE_KEY].as_string() {
+            Some(value) => value,
+            None => {
+                return Err(NotifierError::InvalidContext(
+                    "No message found for the notification".to_string(),
+                ))
+            }
+        };
+
+        // Sets the message by adding the new tag e.g. `New release (v3.2.1) !`
+        self.message = format!("{} (v{}) !", message, last_tag.identifier);
+
+        instance.notify_release(context, self.message.clone()).await?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/sleppa_notifier/src/mattermost/constants.rs
+++ b/crates/sleppa_notifier/src/mattermost/constants.rs
@@ -1,0 +1,10 @@
+/// This module regroups all the constants used in the `mattermost` module.
+
+/// Defines the key used in the `sleppa_notifier` configuration hashmap to acces the url of a Mattermost instance
+pub const MATTERMOST_URL_KEY: &str = "Mattermost_url";
+
+/// Defines the key used in the `sleppa_notifier` configuration hashmap to access the channel_id.
+pub const CHANNEL_ID_KEY: &str = "Channel_id";
+
+/// Defines the key used in the `sleppa_notifier` configuration hashmap to access the token used for credential.
+pub const TOKEN_KEY: &str = "Token";

--- a/crates/sleppa_notifier/src/mattermost/errors.rs
+++ b/crates/sleppa_notifier/src/mattermost/errors.rs
@@ -1,0 +1,37 @@
+/// Enumerates errors that could occur while notifying on a Mattermost instance.
+#[derive(thiserror::Error, Debug)]
+pub enum MattermostError {
+    /// Chained I/O errors
+    #[error(transparent)]
+    IoError(#[from] std::io::Error),
+
+    /// Chained Reqwest errors
+    #[error(transparent)]
+    ReqwestError(#[from] reqwest::Error),
+
+    /// Chained Reqwest errors
+    #[error(transparent)]
+    HeaderError(#[from] reqwest::header::ToStrError),
+
+    /// Chained Reqwest errors
+    #[error(transparent)]
+    HeaderValueError(#[from] reqwest::header::InvalidHeaderValue),
+
+    #[error("No token received from login credentials")]
+    ErrorToken(),
+
+    // No match found when capturing the number with the regex
+    #[error("Error with request status : {0}")]
+    RequestError(String),
+
+    /// Missing key or value in context
+    #[error("Missing key in context: {0}")]
+    InvalidContext(String),
+}
+
+/// Definition of the commit analyzer result
+pub type MattermostResult<R> = Result<R, MattermostError>;
+
+#[cfg(test)]
+/// Result type alias returned by function in unit tests.
+pub type TestResult<T> = std::result::Result<T, Box<dyn std::error::Error>>;

--- a/crates/sleppa_notifier/src/mattermost/mod.rs
+++ b/crates/sleppa_notifier/src/mattermost/mod.rs
@@ -1,0 +1,214 @@
+//! [Mattermost ](https://mattermost.com/) notification module
+//!
+//! This module implements the notification of a new release on the Mattermost platform.
+//! It uses the Mattermost's [API](https://api.mattermost.com/) to defines the [CreatePost] structure
+//! in order to serialize it and send the json request to the server.
+//!
+//! It implements the trait [crate::Notify] to provide a way to send the post to the platform.
+//!
+//! A [Mattermost] instance defines a way to send requests to the Mattermost's API using a token. The token is
+//! usually a [personnal authentication token](https://docs.mattermost.com/developer/personal-access-tokens.html).
+//! The post is send to a channel on Mattermost where the user must have the `create_post` permission.
+//! This channel is defined by its ID which can be retrieved using a Mattermost `GET` request at the url :
+//! `https://your-mattermost-url.com/api/v4/teams/{team_id}/channels/name/{channel_name}`.
+//!
+//! The `team_id` can be retrieved using a Mattermost `GET` request at the url :
+//! `https://your-mattermost-url.com/api/v4/teams`
+//!
+//! More information on the Mattermost's API documention :
+//!  - [channel id](https://api.mattermost.com/#tag/channels/operation/GetChannelByName)
+//!  - [team GUID](https://api.mattermost.com/#tag/teams/operation/GetAllTeams)
+//!
+//! Informations used to send the post to a Mattermost instance are retrived from a [Context] structure.
+//! This context should contain a [NOTIFIER_KEY] associated with its [Configuration] structure.
+//! This [configuration] should contain :
+//!  - [MATTERMOST_URL_KEY] to access the url of the instance
+//!  - [CHANNEL_ID_KEY] to access the channel id to post to
+//!  - [TOKEN_KEY] to access the token used as credential.
+
+pub mod constants;
+pub mod errors;
+
+use crate::{
+    constants::NOTIFIER_KEY,
+    errors::{NotifierError, NotifierResult},
+    mattermost::{
+        constants::{CHANNEL_ID_KEY, MATTERMOST_URL_KEY, TOKEN_KEY},
+        errors::{MattermostError, MattermostResult},
+    },
+    Notify,
+};
+use async_trait::async_trait;
+use reqwest::{
+    header::{self, HeaderMap, HeaderValue},
+    Client,
+};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use sleppa_configuration::Context;
+
+/// Defines the CreatePost object defined by Mattermost's API
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CreatePost {
+    /// The channel to post in
+    channel_id: String,
+    /// The message to post
+    message: String,
+}
+
+/// Defines a Mattermost instance.
+///
+/// This structure represents a Mattermost instance to communicate with.
+/// It is defined by the url of the instance (e.g. https://somemattermostinstance.com), the authentication
+/// to login into the instance, an HTTP client and the token to authenticate to.
+/// The authentication_token is required. A session token should be retrieved if the authentication is made by
+/// an user login. The [login] method does this process.
+pub struct Mattermost {
+    /// The url of the Mattermost instance to post to.
+    pub(crate) instance_url: String,
+    /// The http client using [reqwest].
+    pub(crate) client: Client,
+    /// The token needed to authenticate. Usually a personnale acces token.
+    pub(crate) authentication_token: Option<String>,
+}
+
+impl CreatePost {
+    /// Builds a CreatePost with a given channel and message.
+    pub fn build(channel: &str, message: &str) -> Self {
+        CreatePost {
+            channel_id: channel.to_string(),
+            message: message.to_string(),
+        }
+    }
+}
+
+impl Mattermost {
+    /// Creates a new Mattermost struct with a given instance's url and optionnal token.
+    pub fn new(url: &str, token: Option<String>) -> Self {
+        Self {
+            instance_url: url.to_string(),
+            client: Client::new(),
+            authentication_token: token,
+        }
+    }
+
+    /// Gets the token from a user's login and password.
+    ///
+    /// This method is only usefull when a [Mattermost] is instantiate without a personnel access token.
+    /// This retrieve a session token from a user's login.
+    pub async fn login(&mut self, user: String, password: String) -> MattermostResult<()> {
+        // If the token is already defined then the method stops.
+        if self.authentication_token.is_some() {
+            return Ok(());
+        }
+        let url = format!("{}/api/v4/users/login", self.instance_url);
+
+        // Sends the user's login to the Mattermost instance.
+        let response = self
+            .client
+            .post(&url)
+            .json(&json!({
+                "login_id": user,
+                "password": password,
+            }))
+            .send()
+            .await?;
+
+        if !response.status().is_success() {
+            return Err(MattermostError::RequestError(response.status().to_string()));
+        }
+
+        // Retrieves the session token from the response.
+        let session_token = match response.headers().get("Token") {
+            Some(value) => value,
+            None => return Err(MattermostError::ErrorToken()),
+        };
+
+        // Sets the token to be used by futur login process.
+        self.authentication_token = Some(session_token.to_str()?.to_string());
+
+        Ok(())
+    }
+
+    /// Posts a new message on a Mattermost intance.
+    ///
+    /// This method posts a given [Post] on the specified Mattermost instance.
+    /// To do so, the [Mattermost] structure needs a token to authenticate.
+    pub async fn post(&self, post: CreatePost) -> MattermostResult<()> {
+        let url = format!("{}/api/v4/posts", self.instance_url);
+
+        let token = match &self.authentication_token {
+            Some(value) => format!("Bearer {}", value),
+            None => return Err(MattermostError::ErrorToken()),
+        };
+
+        // Constructs the header of the request.
+        let mut map = HeaderMap::new();
+        map.insert(header::ACCEPT, HeaderValue::from_static("application/json"));
+        map.insert(header::CONTENT_TYPE, HeaderValue::from_static("application/json"));
+        map.insert(header::AUTHORIZATION, HeaderValue::from_str(token.as_str())?);
+
+        // Constructs the body of the request.
+        let body = json!({
+            "channel_id": post.channel_id,
+            "message": post.message,
+        });
+
+        let response = self.client.post(url).headers(map).json(&body).send().await?;
+
+        if !response.status().is_success() {
+            return Err(MattermostError::RequestError(response.status().to_string()));
+        }
+
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl Notify for Mattermost {
+    /// Notifies the new release on a Mattermost instance.
+    ///
+    /// Implementation of the trait [Notify] to send a new post when a new release is published.
+    /// The [Post] is converted to a [CreatePost] in order to be serialized in json to send the request
+    /// to the Mattermost's API.
+    async fn notify_release(&self, context: &Context, message: String) -> NotifierResult<()> {
+        // Retrieves the value from the [Context].
+        let channel_id = match context.configurations[NOTIFIER_KEY].map[CHANNEL_ID_KEY].as_string() {
+            Some(value) => value,
+            None => return Err(NotifierError::InvalidContext("No channel ID found.".to_string())),
+        };
+
+        let token = match context.configurations[NOTIFIER_KEY].map[TOKEN_KEY].as_string() {
+            Some(value) => value,
+            None => {
+                return Err(NotifierError::InvalidContext(
+                    "No token found for authentication.".to_string(),
+                ))
+            }
+        };
+
+        let mattermost_url = match context.configurations[NOTIFIER_KEY].map[MATTERMOST_URL_KEY].as_string() {
+            Some(value) => value,
+            None => {
+                return Err(NotifierError::InvalidContext(
+                    "No URL found for Mattermost instance.".to_string(),
+                ))
+            }
+        };
+
+        let post_to_send = CreatePost::build(channel_id, message.as_str());
+
+        let mattermost = Mattermost::new(mattermost_url, Some(token.to_string()));
+
+        // Publishes a new post on Mattermost
+        match mattermost.post(post_to_send).await {
+            Ok(()) => Ok(()),
+            Err(err) => {
+                return Err(NotifierError::SendingError(err.to_string()));
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/sleppa_notifier/src/mattermost/tests.rs
+++ b/crates/sleppa_notifier/src/mattermost/tests.rs
@@ -1,0 +1,103 @@
+//! Unit tests
+//!
+//! This testing module implements the unit tests for testing mattermost module routines.
+//! To avoir a mocking of a server, we use crendentials as environment variable.
+//! Credentials to use are `log` and `pass`. The first defines the user id and the second its associated
+//! password :
+//! `pass="123abc456" log="mail@mail.com" cargo test -p sleppa_notifier`
+
+use crate::mattermost::{errors::*, *};
+
+// Builds a correct CreatedPost instance with a given channel_id and message
+#[test]
+fn test_can_build() {
+    // Unit test preparation
+    let channel = "channel identifier";
+    let message = "Some message to post";
+
+    // Execution step
+    let created_post = CreatePost::build(channel, message);
+
+    // Asserts the result is correct
+    assert_eq!(created_post.channel_id, channel);
+    assert_eq!(created_post.message, message);
+}
+
+// Builds a correct Mattermost instance with a given user crendentials
+#[test]
+fn test_can_new() {
+    // Unit test preparation
+    let token = "123abc456def".to_string();
+    let url = "www.mattermost.com";
+
+    // Execution step
+    let mattermost = Mattermost::new(url, Some(token.clone()));
+
+    // Asserts the instance is correct
+    assert_eq!(mattermost.instance_url, url);
+    assert_eq!(mattermost.authentication_token, Some(token));
+}
+
+// Tests that a login is correctly done with good datas to a Mattermost instance
+#[tokio::test]
+async fn test_can_login() -> TestResult<()> {
+    // Unit test preparation
+    // Retrieves the user id and password in the environment variable.
+    let password = std::env::var("pass").unwrap();
+    let login = std::env::var("log").unwrap();
+    let url = "https://sofairofficial.cloud.mattermost.com";
+
+    // Constructs a good authentication data
+    let good_authdata = (login.clone(), password.clone());
+    // Constructs a wrong authentication data wiht wrong password
+    let wrong_authdata = (login, "wrong_password".to_string());
+
+    // Constructs a wrong authentication data wiht wrong login_id
+    let wronglogin_authdata = ("wrong@mail.com".to_string(), password);
+
+    // Asserts the token is correctly retrieved
+    assert!(Mattermost::new(url, None)
+        .login(good_authdata.0.clone(), good_authdata.1.clone())
+        .await
+        .is_ok());
+    // Asserts an error occured with a wrong password
+    assert!(Mattermost::new(url, None)
+        .login(wrong_authdata.0, wrong_authdata.1)
+        .await
+        .is_err());
+    // Asserts an error occured with a wrong login_id
+    assert!(Mattermost::new(url, None)
+        .login(wronglogin_authdata.0, wronglogin_authdata.1)
+        .await
+        .is_err());
+    // Asserts an error occured with a wrong url
+    assert!(Mattermost::new("www.wrong-url.com", None)
+        .login(good_authdata.0, good_authdata.1)
+        .await
+        .is_err());
+
+    Ok(())
+}
+
+// Tests a post is correctly created on an existing Mattermost instance.
+#[tokio::test]
+async fn test_can_post() -> TestResult<()> {
+    // Unit test preparation
+    // Retrieves the user id and password in the environment variable.
+    let password = std::env::var("pass").unwrap();
+    let login = std::env::var("log").unwrap();
+
+    let url = "https://sofairofficial.cloud.mattermost.com";
+    let channel_id = "p1kfdiyg53gzjki1cpsfr4fzwe";
+
+    let message = "Test to post a Release";
+    let created_post = CreatePost::build(channel_id, message);
+
+    let mut mattermost = Mattermost::new(url, None);
+    mattermost.login(login, password).await?;
+
+    // Asserts the message is correctly posted
+    assert!(mattermost.post(created_post).await.is_ok());
+
+    Ok(())
+}

--- a/crates/sleppa_notifier/src/tests.rs
+++ b/crates/sleppa_notifier/src/tests.rs
@@ -1,0 +1,104 @@
+//! Unit tests
+//!
+//! This testing module implements the unit tests for testing `sleppa_notifier` crate routines.
+//! To avoir a mocking of a server, we use crendentials as environment variable.
+//!
+//!//! Credentials to use are `log` and `pass`. The first defines the user id and the second its associated
+//! password :
+//! `pass="123abc456" log="mail@mail.com" cargo test -p sleppa_notifier`
+
+use crate::{
+    mattermost::{
+        constants::{CHANNEL_ID_KEY, MATTERMOST_URL_KEY, TOKEN_KEY},
+        Mattermost,
+    },
+    *,
+};
+
+use errors::TestResult;
+use sleppa_configuration::Configuration;
+use sleppa_primitives::{repositories::RepositoryTag, Value};
+use std::collections::HashMap;
+
+/// Tests that a message is correctly posted with a new [NotifierPlugin] instance.
+#[tokio::test]
+async fn test_can_run() -> TestResult<()> {
+    // Unit test preparation
+    // Retrieves the user id and password in the environment variable.
+    let password = std::env::var("pass").unwrap();
+    let login = std::env::var("log").unwrap();
+
+    // Constructs a Mattermost instance to retrieve a session token
+    let mut mm = Mattermost::new("https://sofairofficial.cloud.mattermost.com", None);
+    mm.login(login, password).await?;
+    let token = mm.authentication_token.unwrap();
+
+    // Constructs a new tag
+    let new_tag = RepositoryTag {
+        identifier: "3.2.1".to_string(),
+        hash: "123abc456def".to_string(),
+    };
+
+    let mut notifier = NotifierPlugin::new();
+
+    let mut context = Context {
+        configurations: HashMap::new(), //HashMap<String, Configuration>
+    };
+
+    // Creates a [Configuration] for the notifier plugin
+    let mut config = Configuration {
+        map: HashMap::new(), //HashMap<String, Value>
+    };
+    // Creates a [Configuration] for the general configuration plugin
+    let mut general_config = Configuration {
+        map: HashMap::new(), //HashMap<String, Value>
+    };
+
+    // Populates the Configuration
+    config
+        .map
+        .insert(MESSAGE_KEY.to_string(), Value::String("New release".to_string()));
+
+    config.map.insert(
+        CHANNEL_ID_KEY.to_string(),
+        Value::String("p1kfdiyg53gzjki1cpsfr4fzwe".to_string()),
+    );
+
+    config.map.insert(
+        MATTERMOST_URL_KEY.to_string(),
+        Value::String("https://sofairofficial.cloud.mattermost.com".to_string()),
+    );
+
+    config.map.insert(TOKEN_KEY.to_string(), Value::String(token));
+
+    // Populates the Context
+    context.configurations.insert(NOTIFIER_KEY.to_string(), config);
+
+    // Populates the general Configuration
+    general_config
+        .map
+        .insert(CONFIGURATION_LAST_TAG.to_string(), Value::Tag(new_tag));
+
+    // Populates the Context
+    context
+        .configurations
+        .insert(CONFIGURATION_KEY.to_string(), general_config);
+
+    // Creates the plugin
+    let mattermost = Mattermost::new(
+        context.configurations[&NOTIFIER_KEY.to_string()].map[&MATTERMOST_URL_KEY.to_string()]
+            .as_string()
+            .unwrap(),
+        Some(
+            context.configurations[&NOTIFIER_KEY.to_string()].map[&TOKEN_KEY.to_string()]
+                .as_string()
+                .unwrap()
+                .to_string(),
+        ),
+    );
+
+    // Asserts the message is correctly published by the plugin
+    assert!(notifier.run(&context, mattermost).await.is_ok());
+
+    Ok(())
+}


### PR DESCRIPTION
## Description

This pull request implements a plugin to notify a new release on a collaboration platform such as Mattermost, Zulip or Slack.

The plugin uses the context to access the new tag of the repository.
The plugin is generic over the platform and provides a trait `Notify` with an associated method `notify_release` to publish the post.
The posted message looks like : `New release v3.2.1 !` where `v3.2.1` is the new tag.

At first, the plugin works with Mattermost only by providing a module named `mattermost`.
To post on this platform, the module should access a user with `create_post` persmission in the specified channel.
The channel to post to is defined by its `channel_id` which can be retrieved with the team name and GUID : 
- team_id could be retrieved by a GET request on `https://your-mattermost-url.com/api/v4/teams`
- channel_id could be retrieved by a GET request on `https://your-mattermost-url.com/api/v4/teams/{team_id}/channels/name/{channel_name}`

More API's information on : 
-  [channel id](https://api.mattermost.com/#tag/channels/operation/GetChannelByName)
- [team GUID](https://api.mattermost.com/#tag/teams/operation/GetAllTeams)

## Related issues

closes #17 

## How has this been tested?

The crates contain unit tests in the file `tests.rs`.

**Test configuration**:
* Firmware version: Ubuntu 22.10
* Hardware: Intel i5-5200U, 4.0GiB RAM
* Toolchain: `Rust cargo test`
* SDK: -

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
